### PR TITLE
Import driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /.trash-cache
 /.home
 /.kontainer
+/.trash-conf
 kontainer-engine

--- a/drivers/import/import_driver.go
+++ b/drivers/import/import_driver.go
@@ -1,0 +1,165 @@
+package kubeimport
+
+import (
+	"context"
+
+	"io/ioutil"
+
+	"encoding/base64"
+
+	"fmt"
+
+	"github.com/rancher/kontainer-engine/drivers"
+	"github.com/rancher/kontainer-engine/store"
+	"github.com/rancher/kontainer-engine/types"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type Driver struct {
+	types.Capabilities
+
+	types.UnimplementedVersionAccess
+	types.UnimplementedClusterSizeAccess
+}
+
+func NewDriver() *Driver {
+	return &Driver{}
+}
+
+func (d *Driver) GetCapabilities(ctx context.Context) (*types.Capabilities, error) {
+	return &types.Capabilities{Capabilities: make(map[int64]bool)}, nil
+}
+
+func getDriverOptions() *types.DriverFlags {
+	driverFlag := types.DriverFlags{
+		Options: make(map[string]*types.Flag),
+	}
+	driverFlag.Options["kubeConfig"] = &types.Flag{
+		Type:  types.StringType,
+		Usage: "the contents of the kubeconfig file",
+	}
+	driverFlag.Options["kubeConfigPath"] = &types.Flag{
+		Type:  types.StringType,
+		Usage: "the path to the kubeconfig file",
+	}
+	return &driverFlag
+}
+
+func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags, error) {
+	return getDriverOptions(), nil
+}
+
+func (d *Driver) GetDriverUpdateOptions(ctx context.Context) (*types.DriverFlags, error) {
+	return getDriverOptions(), nil
+}
+
+func (d *Driver) Create(ctx context.Context, opts *types.DriverOptions) (*types.ClusterInfo, error) {
+	logrus.Info("importing kubeconfig file into clusters")
+
+	configPath := opts.StringOptions["kubeConfigPath"]
+
+	var raw []byte
+	var err error
+
+	if configPath == "" {
+		raw = []byte(opts.StringOptions["kubeConfig"])
+	} else {
+		raw, err = ioutil.ReadFile(configPath)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to open kubeconfig file: %v", err)
+		}
+	}
+
+	clusters := &store.KubeConfig{}
+	err = yaml.Unmarshal(raw, clusters)
+
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling kubeconfig: %v", err)
+	}
+
+	info := &types.ClusterInfo{}
+	info.Endpoint = clusters.Clusters[0].Cluster.Server
+	info.Username = clusters.Contexts[0].Context.User
+
+	info.RootCaCertificate = clusters.Clusters[0].Cluster.CertificateAuthorityData
+	info.ClientCertificate = clusters.Users[0].User.ClientCertificateData
+	info.ClientKey = clusters.Users[0].User.ClientKeyData
+
+	info.Username = clusters.Users[0].User.Username
+	info.Password = clusters.Users[0].User.Password
+
+	info.Metadata = make(map[string]string)
+	info.Metadata["Endpoint"] = clusters.Clusters[0].Cluster.Server
+	info.Metadata["Config"] = string(raw)
+
+	info.Metadata["RootCA"] = info.RootCaCertificate
+	info.Metadata["ClientCert"] = info.ClientCertificate
+	info.Metadata["ClientKey"] = info.ClientKey
+
+	return info, nil
+}
+
+func (d *Driver) Update(ctx context.Context, clusterInfo *types.ClusterInfo, opts *types.DriverOptions) (*types.ClusterInfo, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (d *Driver) PostCheck(ctx context.Context, info *types.ClusterInfo) (*types.ClusterInfo, error) {
+	logrus.Info("starting post check")
+
+	capem, err := base64.StdEncoding.DecodeString(info.RootCaCertificate)
+
+	if err != nil {
+		return nil, fmt.Errorf("error decoding root ca certificate: %v", err)
+	}
+
+	key, err := base64.StdEncoding.DecodeString(info.ClientKey)
+
+	if err != nil {
+		return nil, fmt.Errorf("error decoding client key: %v", err)
+	}
+
+	cert, err := base64.StdEncoding.DecodeString(info.ClientCertificate)
+
+	if err != nil {
+		return nil, fmt.Errorf("error decoding client certificate: %v", err)
+	}
+
+	config := &rest.Config{
+		Host: info.Endpoint,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData:   capem,
+			KeyData:  key,
+			CertData: cert,
+		},
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("error creating clientset: %v", err)
+	}
+
+	_, err = clientset.DiscoveryClient.ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Kubernetes server version: %v", err)
+	}
+
+	info.ServiceAccountToken, err = drivers.GenerateServiceAccountToken(clientset)
+
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Info("service account token generated successfully")
+	logrus.Info("post-check completed successfully")
+
+	return info, nil
+}
+
+func (d *Driver) Remove(ctx context.Context, clusterInfo *types.ClusterInfo) error {
+	// Nothing to do
+	return nil
+}

--- a/plugin/drivers.go
+++ b/plugin/drivers.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"github.com/rancher/kontainer-engine/drivers/aks"
 	"github.com/rancher/kontainer-engine/drivers/gke"
+	"github.com/rancher/kontainer-engine/drivers/import"
 	"github.com/rancher/kontainer-engine/drivers/rke"
 	"github.com/rancher/kontainer-engine/types"
 	"github.com/sirupsen/logrus"
@@ -11,9 +12,10 @@ import (
 var (
 	// BuiltInDrivers includes all the buildin supported drivers
 	BuiltInDrivers = map[string]bool{
-		"gke": true,
-		"rke": true,
-		"aks": true,
+		"gke":    true,
+		"rke":    true,
+		"aks":    true,
+		"import": true,
 	}
 )
 
@@ -27,6 +29,8 @@ func Run(driverName string, addrChan chan string) (types.Driver, error) {
 		driver = rke.NewDriver()
 	case "aks":
 		driver = aks.NewDriver()
+	case "import":
+		driver = kubeimport.NewDriver()
 	default:
 		addrChan <- ""
 	}

--- a/scripts/validate
+++ b/scripts/validate
@@ -5,7 +5,7 @@ cd $(dirname $0)/..
 
 echo Running validation
 
-PACKAGES=". $(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
+PACKAGES=". $(find . -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin)' | sed -e 's!^!./!' -e 's!$!/...!')"
 
 echo Running: go vet
 go vet ${PACKAGES}

--- a/service/service.go
+++ b/service/service.go
@@ -71,6 +71,13 @@ func (c controllerConfigGetter) GetConfig() (types.DriverOptions, error) {
 		}
 		data = config
 		flatten(data, &driverOptions)
+	case "import":
+		config, err := toMap(c.clusterSpec.ImportedConfig, "json")
+		if err != nil {
+			return driverOptions, err
+		}
+		data = config
+		flatten(data, &driverOptions)
 	}
 
 	driverOptions.StringOptions["name"] = c.clusterName
@@ -155,6 +162,8 @@ func (e *engineService) convertCluster(name string, spec v3.ClusterSpec) (cluste
 		driverName = "gke"
 	} else if spec.RancherKubernetesEngineConfig != nil {
 		driverName = "rke"
+	} else if spec.ImportedConfig != nil {
+		driverName = "import"
 	}
 	if driverName == "" {
 		return cluster.Cluster{}, fmt.Errorf("no driver config found")

--- a/store/types.go
+++ b/store/types.go
@@ -1,42 +1,45 @@
 package store
 
-type kubeConfig struct {
-	APIVersion     string          `yaml:"apiVersion,omitempty"`
-	Clusters       []configCluster `yaml:"clusters,omitempty"`
-	Contexts       []configContext `yaml:"contexts,omitempty"`
-	Users          []configUser    `yaml:"users,omitempty"`
-	CurrentContext string          `yaml:"current-context,omitempty"`
-	Kind           string          `yaml:"kind,omitempty"`
-	Preferences    string          `yaml:"preferences,omitempty"`
+type KubeConfig struct {
+	APIVersion     string            `yaml:"apiVersion,omitempty"`
+	Clusters       []ConfigCluster   `yaml:"clusters,omitempty"`
+	Contexts       []ConfigContext   `yaml:"contexts,omitempty"`
+	Users          []ConfigUser      `yaml:"users,omitempty"`
+	CurrentContext string            `yaml:"current-context,omitempty"`
+	Kind           string            `yaml:"kind,omitempty"`
+	Preferences    map[string]string `yaml:"preferences,omitempty"`
 }
 
-type configCluster struct {
-	Cluster dataCluster `yaml:"cluster,omitempty"`
+type ConfigCluster struct {
+	Cluster DataCluster `yaml:"cluster,omitempty"`
 	Name    string      `yaml:"name,omitempty"`
 }
 
-type dataCluster struct {
+type DataCluster struct {
+	CertificateAuthority     string `yaml:"certificate-authority,omitempty"`
 	CertificateAuthorityData string `yaml:"certificate-authority-data,omitempty"`
 	Server                   string `yaml:"server,omitempty"`
 }
 
-type configContext struct {
-	Context contextData `yaml:"context,omitempty"`
+type ConfigContext struct {
+	Context ContextData `yaml:"context,omitempty"`
 	Name    string      `yaml:"name,omitempty"`
 }
 
-type contextData struct {
+type ContextData struct {
 	Cluster string `yaml:"cluster,omitempty"`
 	User    string `yaml:"user,omitempty"`
 }
 
-type configUser struct {
+type ConfigUser struct {
 	Name string   `yaml:"name,omitempty"`
-	User userData `yaml:"user,omitempty"`
+	User UserData `yaml:"user,omitempty"`
 }
 
-type userData struct {
-	Token    string `yaml:"token,omitempty"`
-	Username string `yaml:"username,omitempty"`
-	Password string `yaml:"password,omitempty"`
+type UserData struct {
+	Token                 string `yaml:"token,omitempty"`
+	Username              string `yaml:"username,omitempty"`
+	Password              string `yaml:"password,omitempty"`
+	ClientCertificateData string `yaml:"client-certificate-data,omitempty"`
+	ClientKeyData         string `yaml:"client-key-data,omitempty"`
 }


### PR DESCRIPTION
Adding import driver so that k8s configs can be imported into kontainer engine.

Google GKE clusters do not with at the moment because of how they do auth.

I also added a path argument to find in the validate script, so Mac people can run it locally (it defaults to `.` on GNU distros)

