### PR TITLE
Adding labels to drivers

### DIFF
--- a/drivers/aks/aks_driver.go
+++ b/drivers/aks/aks_driver.go
@@ -39,6 +39,9 @@ type state struct {
 	// Cluster Name
 	Name string
 
+	// The name that is displayed to the user on the Rancher UI
+	DisplayName string
+
 	// Cluster info
 	ClusterInfo types.ClusterInfo
 }
@@ -62,6 +65,10 @@ func NewDriver() types.Driver {
 func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags, error) {
 	driverFlag := types.DriverFlags{
 		Options: make(map[string]*types.Flag),
+	}
+	driverFlag.Options["display-name"] = &types.Flag{
+		Type:  types.StringType,
+		Usage: "The name that is displayed to the user on the Rancher UI",
 	}
 	driverFlag.Options["subscription-id"] = &types.Flag{
 		Type:  types.StringType,
@@ -163,6 +170,7 @@ func (d *Driver) GetDriverUpdateOptions(ctx context.Context) (*types.DriverFlags
 func getStateFromOptions(driverOptions *types.DriverOptions) (state, error) {
 	state := state{}
 	state.Name = getValueFromDriverOptions(driverOptions, types.StringType, "name").(string)
+	state.DisplayName = getValueFromDriverOptions(driverOptions, types.StringType, "display-name", "displayName").(string)
 	state.AgentDNSPrefix = getValueFromDriverOptions(driverOptions, types.StringType, "node-dns-prefix", "agentDnsPrefix").(string)
 	state.AgentVMSize = getValueFromDriverOptions(driverOptions, types.StringType, "node-vm-size", "agentVmSize").(string)
 	state.Count = getValueFromDriverOptions(driverOptions, types.IntType, "node-count", "count").(int64)
@@ -366,6 +374,13 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions) (*typ
 
 	publicKeyContents := string(publicKey)
 	tags := make(map[string]*string)
+
+	displayName := driverState.DisplayName
+	if displayName == "" {
+		displayName = driverState.Name
+	}
+	tags["displayName"] = to.StringPtr(displayName)
+
 	exists, err := d.resourceGroupExists(ctx, resourcesClient, driverState.ResourceGroup)
 	if err != nil {
 		return nil, err

--- a/drivers/gke/gke_driver.go
+++ b/drivers/gke/gke_driver.go
@@ -36,6 +36,8 @@ type Driver struct {
 }
 
 type state struct {
+	// The displayed name of the cluster
+	DisplayName string
 	// ProjectID is the ID of your project to use when creating a cluster
 	ProjectID string
 	// The zone to launch the cluster
@@ -103,6 +105,10 @@ func NewDriver() types.Driver {
 func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags, error) {
 	driverFlag := types.DriverFlags{
 		Options: make(map[string]*types.Flag),
+	}
+	driverFlag.Options["display-name"] = &types.Flag{
+		Type:  types.StringType,
+		Usage: "the name of the cluster that should be displayed to the user",
 	}
 	driverFlag.Options["project-id"] = &types.Flag{
 		Type:  types.StringType,
@@ -185,6 +191,7 @@ func getStateFromOpts(driverOptions *types.DriverOptions) (state, error) {
 		},
 	}
 	d.Name = getValueFromDriverOptions(driverOptions, types.StringType, "name").(string)
+	d.DisplayName = getValueFromDriverOptions(driverOptions, types.StringType, "display-name", "displayName").(string)
 	d.ProjectID = getValueFromDriverOptions(driverOptions, types.StringType, "project-id", "projectId").(string)
 	d.Zone = getValueFromDriverOptions(driverOptions, types.StringType, "zone").(string)
 	d.NodePoolID = getValueFromDriverOptions(driverOptions, types.StringType, "nodePool").(string)
@@ -219,6 +226,7 @@ func getStateFromOpts(driverOptions *types.DriverOptions) (state, error) {
 			d.NodeConfig.Labels[kv[0]] = kv[1]
 		}
 	}
+
 	return d, d.validate()
 }
 
@@ -419,6 +427,7 @@ func (d *Driver) generateClusterCreateRequest(state state) *raw.CreateClusterReq
 		Username: "admin",
 	}
 	request.Cluster.NodeConfig = state.NodeConfig
+	request.Cluster.ResourceLabels = map[string]string{"display-name": strings.ToLower(state.DisplayName)}
 	return &request
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -85,6 +85,11 @@ func (c controllerConfigGetter) GetConfig() (types.DriverOptions, error) {
 	}
 
 	driverOptions.StringOptions["name"] = c.clusterName
+	displayName := c.clusterSpec.DisplayName
+	if displayName == "" {
+		displayName = c.clusterName
+	}
+	driverOptions.StringOptions["displayName"] = displayName
 
 	return driverOptions, nil
 }


### PR DESCRIPTION
This change adds labels to the GKE, AKS, and EKS drivers. When a cluster is
created, a label or tag will be added to the GKE, AKS, or EKS cluster
respectively.  The value of the value of the label or tag will be the
display name of the cluster in the rancher UI, allowing the end-user to
better identify what resources correspond to what cluster in Rancher.

Issue:
rancher/rancher#12533
