### PR TITLE
Adding logic to continue after keypair post failure

### DIFF
--- a/drivers/eks/eks_driver.go
+++ b/drivers/eks/eks_driver.go
@@ -361,7 +361,7 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions) (*typ
 	_, err = ec2svc.CreateKeyPair(&ec2.CreateKeyPairInput{
 		KeyName: aws.String(keyPairName),
 	})
-	if err != nil {
+	if err != nil && !isDuplicateKeyError(err) {
 		return nil, fmt.Errorf("error creating key pair %v", err)
 	}
 
@@ -401,6 +401,10 @@ func (d *Driver) Create(ctx context.Context, options *types.DriverOptions) (*typ
 	info := &types.ClusterInfo{}
 	storeState(info, state)
 	return info, nil
+}
+
+func isDuplicateKeyError(err error) bool {
+	return strings.Contains(err.Error(), "already exists")
 }
 
 func isClusterConflict(err error) bool {


### PR DESCRIPTION
This change allows the EKS driver to continue the create process even
after it has failed to post a ec2 key pair after a duplicate key error.
This will prevent multiple interlaced create requests from stepping on
each other and failing.

Issue:
rancher/rancher#12792
rancher/rancher#12796