### PR TITLE
Fix ineffassign in get/set version/cluster size CLI commands

### DIFF
--- a/cmd/get_cluster_size.go
+++ b/cmd/get_cluster_size.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+
 	"github.com/rancher/kontainer-engine/store"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -59,6 +60,9 @@ func getClusterSize(ctx *cli.Context) error {
 		cluster.Driver = rpcClient
 
 		cap, err := cluster.GetCapabilities(context.Background())
+		if err != nil {
+			return fmt.Errorf("error getting capabilities: %v", err)
+		}
 
 		if cap.HasGetClusterSizeCapability() {
 			node, err := cluster.GetClusterSize(context.Background())

--- a/cmd/get_version.go
+++ b/cmd/get_version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+
 	"github.com/rancher/kontainer-engine/store"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -59,6 +60,9 @@ func getVersion(ctx *cli.Context) error {
 		cluster.Driver = rpcClient
 
 		cap, err := cluster.GetCapabilities(context.Background())
+		if err != nil {
+			return fmt.Errorf("error getting capabilities: %v", err)
+		}
 
 		if cap.HasGetVersionCapability() {
 			version, err := cluster.GetVersion(context.Background())

--- a/cmd/set_cluster_size.go
+++ b/cmd/set_cluster_size.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+
 	"github.com/rancher/kontainer-engine/store"
 	"github.com/rancher/kontainer-engine/types"
 	"github.com/sirupsen/logrus"
@@ -66,6 +67,9 @@ func setClusterSize(ctx *cli.Context) error {
 		cluster.Driver = rpcClient
 
 		cap, err := cluster.GetCapabilities(context.Background())
+		if err != nil {
+			return fmt.Errorf("error getting capabilities: %v", err)
+		}
 
 		if cap.HasSetClusterSizeCapability() {
 			err := cluster.SetClusterSize(context.Background(), &types.NodeCount{Count: ctx.Int64("cluster-size")})

--- a/cmd/set_version.go
+++ b/cmd/set_version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+
 	"github.com/rancher/kontainer-engine/store"
 	"github.com/rancher/kontainer-engine/types"
 	"github.com/sirupsen/logrus"
@@ -66,6 +67,9 @@ func setVersion(ctx *cli.Context) error {
 		cluster.Driver = rpcClient
 
 		cap, err := cluster.GetCapabilities(context.Background())
+		if err != nil {
+			return fmt.Errorf("error getting capabilities: %v", err)
+		}
 
 		if cap.HasSetVersionCapability() {
 			err := cluster.SetVersion(context.Background(), &types.KubernetesVersion{Version: ctx.String("version")})


### PR DESCRIPTION
This change fixes an ineffectual assignment of error on the
GetCapabilities func call by adding an `if err != nil` block and return.