### PR TITLE
WIP: Fixing intermittent panic

### DIFF
--- a/types/rpc_client.go
+++ b/types/rpc_client.go
@@ -36,7 +36,7 @@ func (rpc *grpcClient) Create(ctx context.Context, opts *DriverOptions, clusterI
 		ClusterInfo:   clusterInfo,
 	})
 	err = handlErr(err)
-	if o.CreateError != "" && err == nil {
+	if err == nil && o.CreateError != "" {
 		err = errors.New(o.CreateError)
 	}
 	return o, err


### PR DESCRIPTION
Sometimes in the rpc_client.go `Create` func there is a panic because `o`
is nil.  This change fixes it so that `err` is evaulated first and
prevents a runtime panic from occuring.