### PR TITLE
Removing kubeconfig decoding

### DIFF
--- a/drivers/aks/aks_driver.go
+++ b/drivers/aks/aks_driver.go
@@ -720,15 +720,8 @@ func (d *Driver) PostCheck(ctx context.Context, info *types.ClusterInfo) (*types
 		return nil, err
 	}
 
-	decoded := make([]byte, base64.StdEncoding.DecodedLen(len(*result.KubeConfig)))
-	l, err := base64.StdEncoding.Decode(decoded, []byte(*result.KubeConfig))
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode kubeconfig: %v", err)
-	}
-
 	clusterConfig := KubeConfig{}
-	err = yaml.Unmarshal(decoded[:l], &clusterConfig)
+	err = yaml.Unmarshal(*result.KubeConfig, &clusterConfig)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal kubeconfig: %v", err)


### PR DESCRIPTION
This change removes the base64 decoding from aks driver.  Because the
azure sdk changed and started decoding the kubeconfig for us, our
existing code was trying to decode an already decoded string and failed.

Issue:
https://github.com/rancher/rancher/issues/13395