### PR TITLE
Aks vnet resource group

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -32,4 +32,4 @@ github.com/smartystreets/go-aws-auth 8ef1316913ee4f44bc48c2456e44a5c1c68ea53b
 
 github.com/rancher/rke               94862fa2e2b5fb1df658a97b387c83e5c27ec1f1
 github.com/rancher/norman            ff60298f31f081b06d198815b4c178a578664f7d
-github.com/rancher/types             2064f9bf7837f4a35dc4532e0f44a34b3ae223f3
+github.com/rancher/types             d6bddd2513f2f1f7d394133057e11e0e143f21a1

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/cluster_types.go
@@ -200,6 +200,8 @@ type AzureKubernetesServiceConfig struct {
 	VirtualNetwork string `json:"virtualNetwork,omitempty"`
 	// Subnet to use for the AKS Cluster (must be within the virtual network)
 	Subnet string `json:"subnet,omitempty"`
+	// The resource group that the virtual network is in.  If omited it is assumed to match the resource group of the cluster
+	VirtualNetworkResourceGroup string `json:"virtualNetworkResourceGroup,omitempty"`
 }
 
 type AmazonElasticContainerServiceConfig struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go
@@ -239,10 +239,10 @@ var (
 		"v1.10.3-rancher2-1": {
 			Etcd:                      m("quay.io/coreos/etcd:v3.1.12"),
 			Kubernetes:                m("rancher/hyperkube:v1.10.3-rancher2"),
-			Alpine:                    m("rancher/rke-tools:v0.1.9"),
-			NginxProxy:                m("rancher/rke-tools:v0.1.9"),
-			CertDownloader:            m("rancher/rke-tools:v0.1.9"),
-			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.9"),
+			Alpine:                    m("rancher/rke-tools:v0.1.10"),
+			NginxProxy:                m("rancher/rke-tools:v0.1.10"),
+			CertDownloader:            m("rancher/rke-tools:v0.1.10"),
+			KubernetesServicesSidecar: m("rancher/rke-tools:v0.1.10"),
 			KubeDNS:                   m("gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.8"),
 			DNSmasq:                   m("gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8"),
 			KubeDNSSidecar:            m("gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8"),
@@ -300,7 +300,7 @@ var (
 			PluginsDocker: m("plugins/docker:17.12"),
 		},
 		LoggingSystemImages: LoggingSystemImages{
-			Fluentd:                       m("rancher/fluentd:v0.1.8"),
+			Fluentd:                       m("rancher/fluentd:v0.1.9"),
 			FluentdHelper:                 m("rancher/fluentd-helper:v0.1.2"),
 			LogAggregatorFlexVolumeDriver: m("rancher/log-aggregator:v0.1.3"),
 			Elaticsearch:                  m("quay.io/pires/docker-elasticsearch-kubernetes:5.6.2"),


### PR DESCRIPTION
This change allows AKS driver to spin up cluster that have virtual
networks that are in different resources groups than the AKS cluster.
Before the virtual network and resource group needed to be in the same
resource group.

Depends on:
https://github.com/rancher/types/pull/484

Issue:
https://github.com/rancher/rancher/issues/14164