### PR TITLE
Add eu-west-1 to EKS driver

### DIFF
--- a/drivers/eks/eks_driver.go
+++ b/drivers/eks/eks_driver.go
@@ -40,6 +40,7 @@ import (
 var amiForRegion = map[string]string{
 	"us-west-2": "ami-73a6e20b",
 	"us-east-1": "ami-dea4d5a1",
+	"eu-west-1": "ami-066110c1a7466949e",
 }
 
 type Driver struct {


### PR DESCRIPTION
See https://github.com/rancher/rancher/issues/15484. 

This adds the needed AMI to the region -> ami map for eu-west-1

