### PR TITLE
Updated AWS EKS regions to include eu-west-1

### DIFF
--- a/drivers/eks/eks_driver.go
+++ b/drivers/eks/eks_driver.go
@@ -38,6 +38,7 @@ import (
 )
 
 var amiForRegion = map[string]string{
+	"eu-west-1": "ami-066110c1a7466949e",
 	"us-west-2": "ami-73a6e20b",
 	"us-east-1": "ami-dea4d5a1",
 }


### PR DESCRIPTION
This update uses EKS worker AMI v23 for eu-west-1 (Ireland).
Other regions were not updated since the whole cluster would require an update for all worker nodes before adding new ones.

See note from Amazon:
https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html

> **Important**
> 
> These AMIs require the latest AWS CloudFormation worker node template.
> You cannot use these AMIs with a previous version of the worker node
> template; they will fail to join your cluster. Be sure to upgrade any
> existing AWS CloudFormation worker stacks with the latest template
> (URL shown below) before you attempt to use these AMIs.
> 
> > https://amazon-eks.s3-us-west-2.amazonaws.com/cloudformation/2018-08-30/amazon-eks-nodegroup.yaml