### PR TITLE
Fix eks error messages

### DIFF
--- a/drivers/eks/eks_driver.go
+++ b/drivers/eks/eks_driver.go
@@ -303,7 +303,7 @@ func (d *Driver) createStack(svc *cloudformation.CloudFormation, name string, di
 					continue
 				}
 
-				if *event.ResourceStatus == "CREATE_FAILED" && *event.LogicalResourceId == "VPC" {
+				if *event.ResourceStatus == "CREATE_FAILED" {
 					reason = *event.ResourceStatusReason
 					break
 				}

--- a/drivers/eks/eks_driver.go
+++ b/drivers/eks/eks_driver.go
@@ -539,7 +539,7 @@ func isDuplicateKeyError(err error) bool {
 }
 
 func isClusterConflict(err error) bool {
-	return strings.Contains(err.Error(), "http response code was: 409")
+	return err.Error() == "409"
 }
 
 func getEC2KeyPairName(state state) string {


### PR DESCRIPTION
See https://github.com/rancher/rancher/issues/15823

https://github.com/rancher/kontainer-engine/commit/78cbcbfc7ed57b8e4543993298365eacbdf611bc#diff-193f5e744cfdca5a8b1c37da968623f3L313

Caused isClusterConflictError to never work properly.

The other commit allows logicresources besides VPCs to provide the reason for the failure. 

