### PR TITLE
Check for ROLLBACK_IN_PROGRESS in errors

### DIFF
--- a/drivers/eks/eks_driver.go
+++ b/drivers/eks/eks_driver.go
@@ -295,6 +295,11 @@ func (d *Driver) createStack(svc *cloudformation.CloudFormation, name string, di
 					reason = *event.ResourceStatusReason
 					break
 				}
+
+				if *event.ResourceStatus == "ROLLBACK_IN_PROGRESS" {
+					reason = *event.ResourceStatusReason
+					// do not break so that CREATE_FAILED takes priority
+				}
 			}
 		}
 		return nil, fmt.Errorf("stack failed to create: %v", reason)


### PR DESCRIPTION
See: https://github.com/rancher/rancher/issues/16786

When handling errors in stack creation, sometimes there is no CREATE_FAILED event, and the reason is attached to the ROLLBACK_IN_PROGRESS event. 

This change still allows CREATE_FAILED events to take priority.