### PR TITLE
Update AMIs for EKS to address CVE-2018-1002105

### DIFF
--- a/drivers/eks/eks_driver.go
+++ b/drivers/eks/eks_driver.go
@@ -36,9 +36,9 @@ import (
 )
 
 var amiForRegion = map[string]string{
-	"us-west-2": "ami-0a54c984b9f908c81",
-	"us-east-1": "ami-0440e4f6b9713faf6",
-	"eu-west-1": "ami-0c7a4976cb6fafd3a",
+	"us-west-2": "ami-07af9511082779ae7",
+	"us-east-1": "ami-027792c3cc6de7b5b",
+	"eu-west-1": "ami-036130f4127a367f7",
 }
 
 type Driver struct {


### PR DESCRIPTION
New platform version updating Kubernetes to patch level 1.10.11 to address CVE-2018-1002105.
https://docs.aws.amazon.com/eks/latest/userguide/doc-history.html

cf. upstream update: https://github.com/awsdocs/amazon-eks-user-guide/commit/71117cf5551858c3406cb24c63c3cb7c1f2e3493#diff-fe6f31102231b41ff2c53b02da16b32b