### PR TITLE
Change PublicIps parameter to PublicIp in EKS template.

### DIFF
--- a/drivers/eks/templates.go
+++ b/drivers/eks/templates.go
@@ -503,7 +503,7 @@ Resources:
   NodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AssociatePublicIpAddress: !Ref PublicIps
+      AssociatePublicIpAddress: !Ref PublicIp
       IamInstanceProfile: !Ref NodeInstanceProfile
       ImageId: !Ref NodeImageId
       InstanceType: !Ref NodeInstanceType


### PR DESCRIPTION
Problem: Creating and EKS cluster returns a 400 error:
Error creating stack: error creating master: ValidationError: Template format error: Unresolved resource dependencies [PublicIps] in the Resources block of the template status code: 400, request

Solution: Replace the invalid parameter, "PublicIps", with a valid parameter, "PublicIp"

Issue: https://github.com/rancher/rancher/issues/17635