### PR TITLE
Return state info with errors and add wait to remove

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -304,7 +304,10 @@ func (c *Cluster) Remove(ctx context.Context) error {
 		return err
 	}
 
-	return c.Driver.Remove(ctx, toInfo(c))
+	if err := c.Driver.Remove(ctx, toInfo(c)); err != nil {
+		return err
+	}
+	return c.PersistStore.Remove(c.Name)
 }
 
 func (c *Cluster) GetCapabilities(ctx context.Context) (*types.Capabilities, error) {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -298,7 +298,6 @@ func toInfo(c *Cluster) *types.ClusterInfo {
 
 // Remove removes a cluster
 func (c *Cluster) Remove(ctx context.Context) error {
-	defer c.PersistStore.Remove(c.Name)
 	if err := c.restore(); errors.IsNotFound(err) {
 		return nil
 	} else if err != nil {


### PR DESCRIPTION
Problem: When using improper AMI then attempting to delete cluster, deletion displays as completed in UI, but does not complete in EKS.

Solution: Nil was being returned as the cluster state when any error was encountered. This led to an invalid state that caused errors and disrupted the cluster deletion process in EKS. The creation process now returns the state along with the error.

Issue: https://github.com/rancher/rancher/issues/17424