### PR TITLE
cmd: Fix arguments order in NewCluster call

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -136,7 +136,7 @@ func create(ctx *cli.Context) error {
 		return cli.ShowCommandHelp(ctx, "create")
 	}
 
-	cls, err := cluster.NewCluster(driverName, addr, name, configGetter, persistStore)
+	cls, err := cluster.NewCluster(driverName, name, addr, configGetter, persistStore)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In commit bf868603 the order of the arguments `name` and `addr` in the `cluster.NewCluster` definition was swapped. The call for NewCluster in the service implementation was updated accordingly, however the call for NewCluster when using the CLI was not updated in the `cmd` package.

This PR fixes the argument ordering making the CLI work again for cluster creation.