### PR TITLE
Fixed the updating crash

### DIFF
--- a/drivers/gke/gke_driver.go
+++ b/drivers/gke/gke_driver.go
@@ -631,7 +631,11 @@ func (d *Driver) Update(ctx context.Context, info *types.ClusterInfo, opts *type
 		state.NodePoolID = cluster.NodePools[0].Name
 	}
 
-	logrus.Debugf("Updating config. MasterVersion: %s, NodeVersion: %s, NodeCount: %v", state.MasterVersion, state.NodeVersion, state.NodePool.InitialNodeCount)
+	if state.NodePool != nil {
+		logrus.Debugf("Updating config. MasterVersion: %s, NodeVersion: %s, NodeCount: %v", state.MasterVersion, state.NodeVersion, state.NodePool.InitialNodeCount)
+	} else {
+		logrus.Debugf("Updating config. MasterVersion: %s, NodeVersion: %s", state.MasterVersion, state.NodeVersion)
+	}
 
 	if newState.MasterVersion != "" {
 		log.Infof(ctx, "Updating master to %v", newState.MasterVersion)
@@ -665,7 +669,7 @@ func (d *Driver) Update(ctx context.Context, info *types.ClusterInfo, opts *type
 		state.NodeVersion = newState.NodeVersion
 	}
 
-	if newState.NodePool.InitialNodeCount != 0 {
+	if newState.NodePool != nil && newState.NodePool.InitialNodeCount != 0 {
 		log.Infof(ctx, "Updating node number to %v", newState.NodePool.InitialNodeCount)
 		operation, err := svc.Projects.Zones.Clusters.NodePools.SetSize(state.ProjectID, state.Zone, state.Name, state.NodePoolID, &raw.SetNodePoolSizeRequest{
 			NodeCount: newState.NodePool.InitialNodeCount,
@@ -679,7 +683,7 @@ func (d *Driver) Update(ctx context.Context, info *types.ClusterInfo, opts *type
 		}
 	}
 
-	if newState.NodePool.Autoscaling.Enabled {
+	if newState.NodePool != nil && newState.NodePool.Autoscaling != nil && newState.NodePool.Autoscaling.Enabled {
 		log.Infof(ctx, "Updating the autoscaling settings for node pool %s", state.NodePoolID)
 		operation, err := svc.Projects.Zones.Clusters.NodePools.Autoscaling(state.ProjectID, state.Zone, state.Name, state.NodePoolID, &raw.SetNodePoolAutoscalingRequest{
 			Autoscaling: newState.NodePool.Autoscaling,


### PR DESCRIPTION
Problem:
When upgrade rancher from a release version to master, it will crash
because there aren't some added field in the existing crd.

Solution:
When update cluster, check if the added field is "" or nil.

Issue:
https://github.com/rancher/rancher/issues/18154