### PR TITLE
Fixed the problem of legacy authorization field conflict

### DIFF
--- a/drivers/gke/gke_driver.go
+++ b/drivers/gke/gke_driver.go
@@ -180,10 +180,6 @@ func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags
 		Type:  types.BoolType,
 		Usage: "To enable kubernetes alpha feature",
 	}
-	driverFlag.Options["legacy-authorization"] = &types.Flag{
-		Type:  types.BoolType,
-		Usage: "Enable legacy authorization",
-	}
 	driverFlag.Options["enable-stackdriver-logging"] = &types.Flag{
 		Type:  types.BoolPointerType,
 		Usage: "Disable stackdriver logging",
@@ -345,7 +341,7 @@ func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags
 		Usage: "The sub-network to use for the cluster",
 	}
 	driverFlag.Options["enable-legacy-abac"] = &types.Flag{
-		Type:  types.StringType,
+		Type:  types.BoolType,
 		Usage: "Whether to enable legacy abac on the cluster",
 	}
 	driverFlag.Options["locations"] = &types.Flag{
@@ -450,7 +446,7 @@ func getStateFromOpts(driverOptions *types.DriverOptions) (state, error) {
 	d.NodePool.Config.ImageType = options.GetValueFromDriverOptions(driverOptions, types.StringType, "imageType").(string)
 	d.Network = options.GetValueFromDriverOptions(driverOptions, types.StringType, "network").(string)
 	d.SubNetwork = options.GetValueFromDriverOptions(driverOptions, types.StringType, "subNetwork").(string)
-	d.LegacyAbac = options.GetValueFromDriverOptions(driverOptions, types.BoolType, "legacy-authorization", "enableLegacyAbac").(bool)
+	d.LegacyAbac = options.GetValueFromDriverOptions(driverOptions, types.BoolType, "enable-legacy-abac", "enableLegacyAbac").(bool)
 	d.Locations = []string{}
 	locations := options.GetValueFromDriverOptions(driverOptions, types.StringSliceType, "locations").(*types.StringSlice)
 	for _, location := range locations.Value {


### PR DESCRIPTION
Problem:
There are two different options related to a same field in GKE.

Solution:
Remove the redundant options.

Issue:
https://github.com/rancher/rancher/issues/17015