### PR TITLE
Fix the existing AKS cluster displays an error message when upgrading

### DIFF
--- a/drivers/aks/aks_driver.go
+++ b/drivers/aks/aks_driver.go
@@ -808,7 +808,7 @@ func (d *Driver) createOrUpdate(ctx context.Context, options *types.DriverOption
 				DNSPrefix:      to.StringPtr(agentDNSPrefix),
 				Count:          countPointer,
 				MaxPods:        maxPodsPointer,
-				Name:           to.StringPtr(safeSlice(driverState.AgentName, 12)),
+				Name:           to.StringPtr(driverState.AgentName),
 				OsDiskSizeGB:   osDiskSizeGBPointer,
 				OsType:         containerservice.Linux,
 				StorageProfile: agentStorageProfile,


### PR DESCRIPTION
rancher-server

**Problem:**
Change previous cluster agent pool name will cause AKS API error

**Solution:**
Don't change the previous cluster agent pool name

**Issue:**
https://github.com/rancher/rancher/issues/18165