### PR TITLE
Add fields to update options

### DIFF
--- a/drivers/aks/aks_driver.go
+++ b/drivers/aks/aks_driver.go
@@ -404,6 +404,15 @@ func (d *Driver) GetDriverUpdateOptions(ctx context.Context) (*types.DriverFlags
 		Type:  types.StringSliceType,
 		Usage: "Tags for Kubernetes cluster. For example, foo=bar.",
 	}
+	driverFlag.Options["client-id"] = &types.Flag{
+		Type:  types.StringType,
+		Usage: "Azure client ID to use.",
+	}
+	driverFlag.Options["client-secret"] = &types.Flag{
+		Type:     types.StringType,
+		Password: true,
+		Usage:    `Azure client secret associated with the "client id".`,
+	}
 
 	return &driverFlag, nil
 }

--- a/drivers/eks/eks_driver.go
+++ b/drivers/eks/eks_driver.go
@@ -239,6 +239,19 @@ func (d *Driver) GetDriverUpdateOptions(ctx context.Context) (*types.DriverFlags
 		Usage:   "The kubernetes version to update",
 		Default: &types.Default{DefaultString: "1.10"},
 	}
+	driverFlag.Options["access-key"] = &types.Flag{
+		Type:  types.StringType,
+		Usage: "The AWS Client ID to use",
+	}
+	driverFlag.Options["secret-key"] = &types.Flag{
+		Type:     types.StringType,
+		Password: true,
+		Usage:    "The AWS Client Secret associated with the Client ID",
+	}
+	driverFlag.Options["session-token"] = &types.Flag{
+		Type:  types.StringType,
+		Usage: "A session token to use with the client key and secret if applicable.",
+	}
 
 	return &driverFlag, nil
 }

--- a/drivers/gke/gke_driver.go
+++ b/drivers/gke/gke_driver.go
@@ -389,6 +389,11 @@ func (d *Driver) GetDriverUpdateOptions(ctx context.Context) (*types.DriverFlags
 		Type:  types.StringType,
 		Usage: "The kubernetes node version to update",
 	}
+	driverFlag.Options["credential"] = &types.Flag{
+		Type:     types.StringType,
+		Password: true,
+		Usage:    "The contents of the GC credential file",
+	}
 	return &driverFlag, nil
 }
 


### PR DESCRIPTION
Problem:
Secrets are not shown as update fields

Solution:
Add secrets to the list of fields that are returned as update options