### PR TITLE
Don't log warning when driver option value missing

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -433,6 +433,8 @@ func flattenIfNotExist(data map[string]interface{}, driverOptions *types.DriverO
 			} else {
 				flattenIfNotExist(v.(map[string]interface{}), driverOptions)
 			}
+		case nil:
+			logrus.Debugf("could not convert %v because value is nil %v=%v", reflect.TypeOf(v), k, v)
 		default:
 			logrus.Warnf("could not convert %v %v=%v", reflect.TypeOf(v), k, v)
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -129,6 +129,8 @@ func flatten(data map[string]interface{}, driverOptions *types.DriverOptions) {
 			} else {
 				flatten(v.(map[string]interface{}), driverOptions)
 			}
+		case nil:
+			logrus.Debugf("could not convert %v because value is nil %v=%v", reflect.TypeOf(v), k, v)
 		default:
 			logrus.Warnf("could not convert %v %v=%v", reflect.TypeOf(v), k, v)
 		}


### PR DESCRIPTION
Problem:
When we convert kontainer engine driver options, we are not properly
handling the scenario where a key has a nil value.

Solution:
Instead of logging this scenario as a warning, log it as debug as
it is a non-impactful situation.