### PR TITLE
Enable EBS Volume as encyrpted

### DIFF
--- a/drivers/eks/templates.go
+++ b/drivers/eks/templates.go
@@ -511,6 +511,7 @@ Resources:
             VolumeSize: !Ref NodeVolumeSize
             VolumeType: gp2
             DeleteOnTermination: true
+            Encrypted: true
       UserData: !Base64
         'Fn::Sub': %q
 


### PR DESCRIPTION
Additional volume other than the root one created during EKS cluster creation is not encrypted so updating the CFT to enable encryption option