### PR TITLE
drivers/eks: Stop waiting for cluster ready if it has a failed status

### DIFF
--- a/drivers/eks/eks_driver.go
+++ b/drivers/eks/eks_driver.go
@@ -843,7 +843,7 @@ func (d *Driver) waitForClusterReady(svc *eks.EKS, state state) (*eks.DescribeCl
 	var err error
 
 	status := ""
-	for status != "ACTIVE" {
+	for status != eks.ClusterStatusActive {
 		time.Sleep(30 * time.Second)
 
 		logrus.Infof("Waiting for cluster to finish provisioning")
@@ -864,6 +864,12 @@ func (d *Driver) waitForClusterReady(svc *eks.EKS, state state) (*eks.DescribeCl
 		}
 
 		status = *cluster.Cluster.Status
+
+		if status == eks.ClusterStatusFailed {
+			return nil, fmt.Errorf("creation failed for cluster named %q with ARN %q",
+				aws.StringValue(cluster.Cluster.Name),
+				aws.StringValue(cluster.Cluster.Arn))
+		}
 	}
 
 	return cluster, nil


### PR DESCRIPTION
There's not much that can be done when a cluster enters in FAILED state we should at least stop waiting and return an error message.