### PR TITLE
Open port 80 from control plane to workers in EKS default SG

### DIFF
--- a/drivers/eks/templates.go
+++ b/drivers/eks/templates.go
@@ -474,6 +474,28 @@ Resources:
       ToPort: 443
       FromPort: 443
 
+  NodeSecurityGroupFromControlPlaneOn80Ingress:
+    Type: AWS::EC2::SecurityGroupIngress
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow pods to receive communication from cluster control plane via HTTP service proxy on port 80
+      GroupId: !Ref NodeSecurityGroup
+      SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+
+  ControlPlaneEgressToNodeSecurityGroupOn80:
+    Type: AWS::EC2::SecurityGroupEgress
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow the cluster control plane to communicate with pods via HTTP service proxy on port 80
+      GroupId: !Ref ClusterControlPlaneSecurityGroup
+      DestinationSecurityGroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+
   NodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/16968

Problem:
Service proxy does not work in EKS using the generated security group.

Solution:
Open port 80 from the control plane to workers so that HTTP service proxy is feasible.

Note:
It is not included in the minimum required and recommended security group settings, but is needed for proxy functionality.
https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html