### PR TITLE
Update EKS default k8s version

### DIFF
--- a/drivers/eks/eks_driver.go
+++ b/drivers/eks/eks_driver.go
@@ -274,7 +274,7 @@ func (d *Driver) GetDriverCreateOptions(ctx context.Context) (*types.DriverFlags
 	driverFlag.Options["kubernetes-version"] = &types.Flag{
 		Type:    types.StringType,
 		Usage:   "The kubernetes master version",
-		Default: &types.Default{DefaultString: "1.10"},
+		Default: &types.Default{DefaultString: "1.13"},
 	}
 
 	return &driverFlag, nil
@@ -288,7 +288,7 @@ func (d *Driver) GetDriverUpdateOptions(ctx context.Context) (*types.DriverFlags
 	driverFlag.Options["kubernetes-version"] = &types.Flag{
 		Type:    types.StringType,
 		Usage:   "The kubernetes version to update",
-		Default: &types.Default{DefaultString: "1.10"},
+		Default: &types.Default{DefaultString: "1.13"},
 	}
 	driverFlag.Options["access-key"] = &types.Flag{
 		Type:  types.StringType,


### PR DESCRIPTION
Problem:
EKS k8s default version for create/update is 1.10. 1.10 is no longer supported for EKS and keeping it as the value for k8s version parameter would cause an error.

Solution:
Update EKS default k8s version for create/update to 1.13. Now, the default k8s version for EKS is the same as the on in the AWS console.

Issue:
https://github.com/rancher/rancher/issues/20342