### PR TITLE
Handle EBS encryption flag for eks driver

### DIFF
--- a/drivers/eks/eks_driver.go
+++ b/drivers/eks/eks_driver.go
@@ -345,7 +345,7 @@ func getStateFromOptions(driverOptions *types.DriverOptions) (state, error) {
 	state.AMI = options.GetValueFromDriverOptions(driverOptions, types.StringType, "ami").(string)
 	state.AssociateWorkerNodePublicIP, _ = options.GetValueFromDriverOptions(driverOptions, types.BoolPointerType, "associate-worker-node-public-ip", "associateWorkerNodePublicIp").(*bool)
 	state.KeyPairName = options.GetValueFromDriverOptions(driverOptions, types.StringType, "keyPairName").(string)
-	state.EBSEncryption = options.GetValueFromDriverOptions(driverOptions, types.BoolPointerType, "ebs-encryption", "EBSEncryption").(bool)
+	state.EBSEncryption = options.GetValueFromDriverOptions(driverOptions, types.BoolType, "ebs-encryption", "EBSEncryption").(bool)
 
 	// UserData
 	state.UserData = options.GetValueFromDriverOptions(driverOptions, types.StringType, "user-data", "userData").(string)


### PR DESCRIPTION
This PR fixs the type of the EBS driver to be a boolean pointer and adds nil dereference protection.
EBS encryption defaults to false if not set.