### PR TITLE
[RKE driver] do not overwrite err on creation

### DIFF
--- a/drivers/rke/rke_driver.go
+++ b/drivers/rke/rke_driver.go
@@ -160,7 +160,7 @@ func (d *Driver) Create(ctx context.Context, opts *types.DriverOptions, info *ty
 	dialers, externalFlags := d.getFlags(rkeConfig, stateDir)
 	APIURL, caCrt, clientCert, clientKey, certs, err := clusterUp(ctx, &rkeConfig, dialers, externalFlags, data)
 	if len(certs) > 0 {
-		certsStr, err = rkecerts.ToString(certs)
+		certsStr, _ = rkecerts.ToString(certs)
 	}
 	if err != nil && certsStr == "" {
 		return d.save(&types.ClusterInfo{


### PR DESCRIPTION
In current implementation, clusterUP results will be overwritten with json encode results.
We should not do that.