### PR TITLE
Fix enabling GKE NetworkPolicies

### DIFF
--- a/drivers/gke/gke_driver.go
+++ b/drivers/gke/gke_driver.go
@@ -736,6 +736,12 @@ func (d *Driver) generateClusterCreateRequest(state state) *raw.CreateClusterReq
 		KubernetesDashboard:      &raw.KubernetesDashboard{Disabled: !state.EnableKubernetesDashboard},
 		NetworkPolicyConfig:      &raw.NetworkPolicyConfig{Disabled: disableNetworkPolicyConfig},
 	}
+	if !disableNetworkPolicyConfig {
+		request.Cluster.NetworkPolicy = &raw.NetworkPolicy{
+			Enabled:  true,
+			Provider: "CALICO",
+		}
+	}
 	request.Cluster.Network = state.Network
 	request.Cluster.Subnetwork = state.SubNetwork
 	request.Cluster.LegacyAbac = &raw.LegacyAbac{


### PR DESCRIPTION
The kontainer-engine-driver only activates the NetworkPolicy Add-On, but does not set the networkPolicy config object (see https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy#api).

This fixes https://github.com/rancher/rancher/issues/26917.