### PR TITLE
Add flag --external-driver-addr

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -73,7 +73,7 @@ func createWapper(ctx *cli.Context) error {
 	return ctx.App.Run(os.Args)
 }
 
-func flagExternalDriverLookup()string{
+func flagExternalDriverLookup() string {
 	return flagHackLookup("--external-driver-addr")
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -73,6 +73,10 @@ func createWapper(ctx *cli.Context) error {
 	return ctx.App.Run(os.Args)
 }
 
+func flagExternalDriverLookup()string{
+	return flagHackLookup("--external-driver-addr")
+}
+
 func flagHackLookup(flagName string) string {
 	// e.g. "-d" for "--driver"
 	flagPrefix := flagName[1:3]

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -16,14 +16,14 @@ func runRPCDriver(driverName string) (types.CloseableDriver, string, error) {
 
 	externalDriverAddr := flagExternalDriverLookup()
 
-	if externalDriverAddr == ""{
+	if externalDriverAddr == "" {
 		creator := drivers.Drivers[driverName]
 		if creator == nil {
 			return nil, "", fmt.Errorf("no driver %v found", driverName)
 		}
 		go types.NewServer(creator, addrChan).ServeOrDie(service.ListenAddress)
-	}else{
-		go func(){ addrChan <- externalDriverAddr }()
+	} else {
+		go func() { addrChan <- externalDriverAddr }()
 	}
 
 	addr := <-addrChan

--- a/main.go
+++ b/main.go
@@ -72,6 +72,10 @@ func main() {
 			Name:  "plugin-listen-addr",
 			Usage: "The listening address for rpc plugin server",
 		},
+		cli.StringFlag{
+			Name: "external-driver-addr",
+			Usage: "The listening address of an external driver",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 			Usage: "The listening address for rpc plugin server",
 		},
 		cli.StringFlag{
-			Name: "external-driver-addr",
+			Name:  "external-driver-addr",
 			Usage: "The listening address of an external driver",
 		},
 	}


### PR DESCRIPTION
Adding flag --external-driver-addr to allow the kontainer-engine to communicate with external driver clusters.