### PR TITLE
Only send PrivateClusterConfig for private clusters

### DIFF
--- a/drivers/gke/gke_driver.go
+++ b/drivers/gke/gke_driver.go
@@ -751,7 +751,9 @@ func (d *Driver) generateClusterCreateRequest(state state) *raw.CreateClusterReq
 		request.Cluster.MasterAuthorizedNetworksConfig = state.MasterAuthorizedNetworksConfig
 	}
 
-	request.Cluster.PrivateClusterConfig = state.PrivateClusterConfig
+	if state.PrivateClusterConfig != nil && state.PrivateClusterConfig.EnablePrivateNodes {
+		request.Cluster.PrivateClusterConfig = state.PrivateClusterConfig
+	}
 	request.Cluster.IpAllocationPolicy = state.IPAllocationPolicy
 	if request.Cluster.IpAllocationPolicy.UseIpAliases == true &&
 		request.Cluster.IpAllocationPolicy.ClusterIpv4CidrBlock != "" {


### PR DESCRIPTION
GKE rolled out a change that denies setting PrivateClusterConfig on
Cluster objects if they are not using private nodes, so update the
driver to conform with this.

https://github.com/rancher/rancher/issues/33277